### PR TITLE
AI-28: Add background gradient and images

### DIFF
--- a/assets/square-bubble-2-wireframe.svg
+++ b/assets/square-bubble-2-wireframe.svg
@@ -1,0 +1,15 @@
+<svg width="536" height="603" viewBox="0 0 536 603" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_229_986)">
+<path d="M434.94 228.714L501.852 117.373L455.221 93.7319L388.299 205.113L434.94 228.714Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M147.232 509.129L482.601 429.533L436.023 406.194L100.752 485.765L147.232 509.129Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M482.602 429.534L434.94 228.714L388.299 205.113L436.023 406.194L482.602 429.534Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31.4229 194.391L455.152 93.8252L388.239 205.165L435.901 405.984L100.532 485.579L31.4229 194.391Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M78.1235 217.938L501.854 117.372L434.941 228.712L482.603 429.531L147.233 509.127L78.1235 217.938Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31.4229 194.391L455.152 93.8252L501.852 117.372L78.1226 217.939L31.4229 194.391Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_229_986">
+<rect width="500" height="500" fill="white" transform="translate(0 116.124) rotate(-13.3513)"/>
+</clipPath>
+</defs>
+</svg>

--- a/assets/square-bubble-wireframe.svg
+++ b/assets/square-bubble-wireframe.svg
@@ -1,18 +1,18 @@
-<svg width="189" height="248" viewBox="0 0 189 248" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_110_314)">
-<path d="M-2.71631 18.5232L176.857 69.4939L145.49 180.001L78.1501 160.887L47.4296 183.664L33.2569 148.144L-34.083 129.03L-2.71631 18.5232Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M26.5808 162.074L-31.0897 145.704L-34.083 129.03L33.2568 148.144L26.5808 162.074Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M134.183 192.616L76.5122 176.246L78.1499 160.886L145.474 179.996L134.183 192.616Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M0.276862 35.198L165.549 82.1096L176.841 69.4895L-2.71631 18.5232L0.276862 35.198Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M165.55 82.1096L176.841 69.4895" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M0.276862 35.198L-2.71631 18.5232L-34.083 129.03L-31.0897 145.704L0.276862 35.198Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M165.534 82.1052L176.841 69.4895L145.474 179.996L134.167 192.611L165.534 82.1052Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M76.5125 176.246L41.9406 203.003L47.4298 183.664L78.1502 160.886L76.5125 176.246Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M41.9406 203.003L26.581 162.074L33.2569 148.144L47.4297 183.664L41.9406 203.003Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="598" height="619" viewBox="0 0 598 619" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_229_969)">
+<path d="M120.709 46.9709L569.642 174.398L491.225 450.664L322.875 402.879L246.074 459.824L210.642 371.023L42.2928 323.238L120.709 46.9709Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M193.953 405.847L49.7762 364.924L42.293 323.238L210.643 371.023L193.953 405.847Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M462.957 482.203L318.781 441.279L322.875 402.879L491.187 450.654L462.957 482.203Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M128.192 88.6579L541.374 205.937L569.603 174.387L120.709 46.9709L128.192 88.6579Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M541.374 205.937L569.604 174.387" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M128.192 88.6579L120.709 46.9709L42.2928 323.238L49.776 364.923L128.192 88.6579Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M541.336 205.926L569.604 174.387L491.187 450.654L462.919 482.192L541.336 205.926Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M318.782 441.279L232.352 508.171L246.075 459.824L322.876 402.88L318.782 441.279Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M232.352 508.171L193.953 405.847L210.643 371.023L246.075 459.824L232.352 508.171Z" stroke="white" stroke-opacity="0.1" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 <defs>
-<clipPath id="clip0_110_314">
-<rect width="200" height="200" fill="white" transform="translate(-4.38867) rotate(15.8463)"/>
+<clipPath id="clip0_229_969">
+<rect width="500" height="500" fill="white" transform="translate(116.529 0.663086) rotate(15.8463)"/>
 </clipPath>
 </defs>
 </svg>

--- a/index.css
+++ b/index.css
@@ -113,36 +113,207 @@ table {
   border-spacing: 0;
 }
 
+.background-gradient-image {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  z-index: -1;
+}
+.background-gradient-image.-top {
+  background: radial-gradient(circle at 0px 0px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 800px, rgba(26, 187, 169, 0.35), transparent 380px);
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-top {
+    background: radial-gradient(circle at 0px 0px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 800px, rgba(26, 187, 169, 0.35), transparent 600px);
+  }
+}
+.background-gradient-image.-mission {
+  background: radial-gradient(circle at 0px 500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 1500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 2500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 3500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 2000px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 3000px, rgba(26, 187, 169, 0.35), transparent 380px);
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-mission {
+    background: radial-gradient(circle at 0px 500px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 1900px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 3300px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 4700px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 2400px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 3800px, rgba(26, 187, 169, 0.35), transparent 600px);
+  }
+}
+@container body (min-width: 768px) {
+  .background-gradient-image.-mission {
+    background: radial-gradient(circle at 0px 500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 1500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 2500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 2000px, rgba(26, 187, 169, 0.35), transparent 380px);
+  }
+  @container body (min-width: 1024px) {
+    .background-gradient-image.-mission {
+      background: radial-gradient(circle at 0px 500px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 1900px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 3300px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 2400px, rgba(26, 187, 169, 0.35), transparent 600px);
+    }
+  }
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-mission {
+    background: radial-gradient(circle at 0px 500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 1500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 2000px, rgba(26, 187, 169, 0.35), transparent 380px);
+  }
+  @container body (min-width: 1024px) {
+    .background-gradient-image.-mission {
+      background: radial-gradient(circle at 0px 500px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 1900px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 2400px, rgba(26, 187, 169, 0.35), transparent 600px);
+    }
+  }
+}
+.background-gradient-image.-schedule {
+  background: radial-gradient(circle at 0px 950px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 350px, rgba(26, 187, 169, 0.35), transparent 380px);
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-schedule {
+    background: radial-gradient(circle at 0px 950px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 350px, rgba(26, 187, 169, 0.35), transparent 600px);
+  }
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-schedule {
+    background: radial-gradient(circle at 0px 750px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 1750px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 1300px, rgba(26, 187, 169, 0.35), transparent 380px);
+  }
+  @container body (min-width: 1024px) {
+    .background-gradient-image.-schedule {
+      background: radial-gradient(circle at 0px 750px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 2150px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 1300px, rgba(26, 187, 169, 0.35), transparent 600px);
+    }
+  }
+}
+.background-gradient-image.-rules {
+  background: radial-gradient(circle at 0px 1200px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 0px 2200px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 700px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 1700px, rgba(26, 187, 169, 0.35), transparent 380px);
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-rules {
+    background: radial-gradient(circle at 0px 1200px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 0px 2600px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 700px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 2100px, rgba(26, 187, 169, 0.35), transparent 600px);
+  }
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-rules {
+    background: none;
+  }
+}
+.background-gradient-image.-faqs {
+  background: radial-gradient(circle at 0px 1700px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 380px);
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-faqs {
+    background: radial-gradient(circle at 0px 1700px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 1000px, rgba(26, 187, 169, 0.35), transparent 600px);
+  }
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image.-faqs {
+    background: radial-gradient(circle at 0px 1500px, rgba(26, 187, 169, 0.35), transparent 380px), radial-gradient(circle at 100% 900px, rgba(26, 187, 169, 0.35), transparent 380px);
+  }
+  @container body (min-width: 1024px) {
+    .background-gradient-image.-faqs {
+      background: radial-gradient(circle at 0px 1500px, rgba(26, 187, 169, 0.35), transparent 600px), radial-gradient(circle at 100% 900px, rgba(26, 187, 169, 0.35), transparent 600px);
+    }
+  }
+}
+.background-gradient-image img {
+  width: 200px;
+  height: 200px;
+  position: absolute;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img {
+    width: 500px;
+    height: 500px;
+  }
+}
+.background-gradient-image img#headImage {
+  top: 60px;
+}
+.background-gradient-image img#magnifyingGlassImage {
+  right: 24px;
+  top: 625px;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#magnifyingGlassImage {
+    top: 500px;
+  }
+}
+.background-gradient-image img#stairsImage {
+  left: -40px;
+  top: 450px;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#stairsImage {
+    top: 200px;
+  }
+}
+.background-gradient-image img#decagonImage {
+  right: -40px;
+  top: 2850px;
+}
+@container body (min-width: 768px) {
+  .background-gradient-image img#decagonImage {
+    top: 1900px;
+  }
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#decagonImage {
+    right: 0;
+    top: 2000px;
+  }
+}
+.background-gradient-image img#exclamationMarkImage {
+  left: -20px;
+  top: 950px;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#exclamationMarkImage {
+    top: 500px;
+  }
+}
+.background-gradient-image img#eyeImage {
+  right: -50px;
+  top: 575px;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#eyeImage {
+    top: 650px;
+  }
+}
+.background-gradient-image img#squareBubbleImage {
+  left: -40px;
+  top: 2075px;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#squareBubbleImage {
+    top: 1550px;
+  }
+}
+.background-gradient-image img#secondSquareBubbleImage {
+  right: -50px;
+  top: 850px;
+}
+@container body (min-width: 1024px) {
+  .background-gradient-image img#secondSquareBubbleImage {
+    top: 650px;
+  }
+}
+
 #top-nav {
-  background: #00023d;
-  padding: 16px 0;
+  background-color: #00023d;
   position: sticky;
   top: 0;
   left: 0;
   z-index: 99;
   width: 100%;
 }
-@container body (min-width: 1024px) {
-  #top-nav {
-    padding: 20px 0;
-  }
-}
 
 .container {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  padding: 0 24px;
+  padding: 16px 24px;
+  background: radial-gradient(circle at -100px -110px, rgba(26, 187, 169, 0.5), #00023d 500px);
 }
 @container body (min-width: 1024px) {
   .container {
-    padding: 0 150px;
+    padding: 20px 150px;
     justify-content: space-between;
+    background: radial-gradient(circle at -100px -200px, rgba(26, 187, 169, 0.5), #00023d 750px);
   }
 }
 @container body (min-width: 1240px) {
   .container {
-    padding: 0 200px;
+    padding: 20px 200px;
   }
 }
 
@@ -444,22 +615,6 @@ table {
   margin-top: 8px;
 }
 
-/* #mission {
-  position: relative;
-  height: 100%;
-} */
-.mission-header-goals-wrapper {
-  /* &:before {
-    content: ' ';
-    display: block;
-    position: absolute;
-    top: 545px;
-    left: 0;
-    width: 200px;
-    height: 200px;
-    background: url('./assets/stairs-wireframe.svg') no-repeat;
-  } */
-}
 .mission-header-goals-wrapper h2 {
   margin: 0 0 24px -10px;
 }
@@ -807,14 +962,6 @@ body mark {
   line-height: 0;
   padding: 0 4px 12px;
   background-color: rgba(26, 187, 169, 0.5);
-}
-
-#gradient {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-image: radial-gradient(circle at top left, rgba(26, 187, 169, 0.5), transparent 30%), radial-gradient(circle at bottom right, rgba(26, 187, 169, 0.5), #00023d 30%);
-  z-index: -1;
 }
 
 section {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,14 @@
   </head>
   <body id="home">
     <div class="body-container">
-      <div id="gradient"></div>
+      <div class="background-gradient-image -top">
+        <img id="headImage" src="./assets/head_wireframe.svg" alt="" />
+        <img
+          id="magnifyingGlassImage"
+          src="./assets/magnify-glass-wireframe.svg"
+          alt=""
+        />
+      </div>
       <!-- NAV SECTION -->
       <div id="top-nav">
         <div class="container">
@@ -112,6 +119,11 @@
 
       <!-- THE MISSION SECTION -->
       <section id="mission">
+        <div class="background-gradient-image -mission">
+          <img id="stairsImage" src="./assets/stairs-wireframe.svg" alt="" />
+          <img id="decagonImage" src="./assets/decagon-wireframe.svg" alt="" />
+        </div>
+
         <div class="mission-header-goals-wrapper">
           <div>
             <h2>
@@ -265,6 +277,13 @@
 
       <!-- SCHEDULE SECTION -->
       <section id="schedule">
+        <div class="background-gradient-image -schedule">
+          <img
+            id="exclamationMarkImage"
+            src="./assets/exclamation-mark-wireframe.svg"
+            alt=""
+          />
+        </div>
         <h2>
           <mark class="mark-teal -center">Schedule</mark>
         </h2>
@@ -298,6 +317,14 @@
 
       <!-- RULES SECTION -->
       <section id="rules" class="max-width-686">
+        <div class="background-gradient-image -rules">
+          <img id="eyeImage" src="./assets/eye-focus-wireframe.svg" alt="" />
+          <img
+            id="squareBubbleImage"
+            src="./assets/square-bubble-wireframe.svg"
+            alt=""
+          />
+        </div>
         <h2>
           <mark class="mark-teal -center">Rules</mark>
         </h2>
@@ -372,6 +399,13 @@
 
       <!-- FAQS SECTION -->
       <section id="faqs" class="max-width-686">
+        <div class="background-gradient-image -faqs">
+          <img
+            id="secondSquareBubbleImage"
+            src="./assets/square-bubble-2-wireframe.svg"
+            alt=""
+          />
+        </div>
         <h2>
           <mark class="mark-teal -center">FAQs</mark>
         </h2>

--- a/index.js
+++ b/index.js
@@ -145,3 +145,17 @@ window.addEventListener('scroll', () => {
     }
   });
 });
+
+// BACKGROUND GRADIENTS
+// Note: I originally had the height set as 100% on the .background-gradient-image class,
+// this worked on all browsers except for Firefox. Firefox did not appreciate
+// elements being absolutely positioned with 100% height, so the elements overflowed the body.
+// I tried a few different things to fix this, but I came up with using javascript to set the height
+// of the background gradient containers to 100% minus the offset of the container.
+const backgroundGradientContainers = document.querySelectorAll(
+  '.background-gradient-image'
+);
+
+backgroundGradientContainers.forEach((container) => {
+  container.style.height = `calc(100% - ${container.offsetTop}px)`;
+});

--- a/styles/_colors.scss
+++ b/styles/_colors.scss
@@ -3,5 +3,6 @@ $color-blue: #00023d;
 $color-bright-teal: #00ffe2;
 $color-teal: #1abba9;
 $color-teal-50: rgba(26, 187, 169, 0.5);
+$color-teal-35: rgba(26, 187, 169, 0.35);
 $color-white: #ffffff;
 $color-white-50: rgba(255, 255, 255, 0.5);

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,5 +1,6 @@
 @use './reset';
 @use './colors';
+@use './sections/background-gradient';
 @use './sections/nav';
 @use './sections/hero';
 @use './sections/mission';
@@ -43,23 +44,6 @@ body {
   line-height: 0;
   padding: 0 4px 12px;
   background-color: colors.$color-teal-50;
-}
-
-#gradient {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-image: radial-gradient(
-      circle at top left,
-      colors.$color-teal-50,
-      transparent 30%
-    ),
-    radial-gradient(
-      circle at bottom right,
-      colors.$color-teal-50,
-      colors.$color-blue 30%
-    );
-  z-index: -1;
 }
 
 section {
@@ -185,7 +169,7 @@ ol {
 
   li::marker {
     font-weight: 500;
-    font-size: 1.125rem; 
+    font-size: 1.125rem;
   }
 
   li {

--- a/styles/sections/_background-gradient.scss
+++ b/styles/sections/_background-gradient.scss
@@ -1,0 +1,221 @@
+@use '../colors';
+
+@function add-repeating-gradient(
+  $left: 0px,
+  $top: 500,
+  $numberOfGradients: 1,
+  $transparencySize: 380px,
+  $distanceBetweenGradients: 1000
+) {
+  $val: radial-gradient(
+    circle at $left $top + #{'px'},
+    colors.$color-teal-35,
+    transparent $transparencySize
+  );
+  @for $i from 1 to $numberOfGradients {
+    $top: $top + $distanceBetweenGradients;
+    $val: #{$val},
+      radial-gradient(
+        circle at $left $top + #{'px'},
+        colors.$color-teal-35,
+        transparent $transparencySize
+      );
+  }
+  @return $val;
+}
+
+@mixin addBackgroundGradients(
+  $left-amount: 0,
+  $left-top: 0,
+  $right-amount: 0,
+  $right-top: 0
+) {
+  background: add-repeating-gradient(0px, $left-top, $left-amount, 380px, 1000),
+    add-repeating-gradient(100%, $right-top, $right-amount, 380px, 1000);
+
+  @container body (min-width: 1024px) {
+    background: add-repeating-gradient(
+        0px,
+        $left-top,
+        $left-amount,
+        600px,
+        1400
+      ),
+      add-repeating-gradient(100%, $right-top, $right-amount, 600px, 1400);
+  }
+}
+
+.background-gradient-image {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  z-index: -1;
+
+  &.-top {
+    @include addBackgroundGradients(
+      $left-amount: 1,
+      $left-top: 0,
+      $right-amount: 1,
+      $right-top: 800
+    );
+  }
+
+  &.-mission {
+    @include addBackgroundGradients(
+      $left-amount: 4,
+      $left-top: 500,
+      $right-amount: 3,
+      $right-top: 1000
+    );
+
+    @container body (min-width: 768px) {
+      @include addBackgroundGradients(
+        $left-amount: 3,
+        $left-top: 500,
+        $right-amount: 2,
+        $right-top: 1000
+      );
+    }
+
+    @container body (min-width: 1024px) {
+      @include addBackgroundGradients(
+        $left-amount: 2,
+        $left-top: 500,
+        $right-amount: 2,
+        $right-top: 1000
+      );
+    }
+  }
+
+  &.-schedule {
+    @include addBackgroundGradients(
+      $left-amount: 1,
+      $left-top: 950,
+      $right-amount: 1,
+      $right-top: 350
+    );
+
+    @container body (min-width: 1024px) {
+      @include addBackgroundGradients(
+        $left-amount: 2,
+        $left-top: 750,
+        $right-amount: 1,
+        $right-top: 1300
+      );
+    }
+  }
+
+  &.-rules {
+    @include addBackgroundGradients(
+      $left-amount: 2,
+      $left-top: 1200,
+      $right-amount: 2,
+      $right-top: 700
+    );
+
+    @container body (min-width: 1024px) {
+      background: none;
+    }
+  }
+
+  &.-faqs {
+    @include addBackgroundGradients(
+      $left-amount: 1,
+      $left-top: 1700,
+      $right-amount: 1,
+      $right-top: 1000
+    );
+
+    @container body (min-width: 1024px) {
+      @include addBackgroundGradients(
+        $left-amount: 1,
+        $left-top: 1500,
+        $right-amount: 1,
+        $right-top: 900
+      );
+    }
+  }
+
+  img {
+    width: 200px;
+    height: 200px;
+    position: absolute;
+
+    @container body (min-width: 1024px) {
+      width: 500px;
+      height: 500px;
+    }
+
+    &#headImage {
+      top: 60px;
+    }
+
+    &#magnifyingGlassImage {
+      right: 24px;
+      top: 625px;
+
+      @container body (min-width: 1024px) {
+        top: 500px;
+      }
+    }
+
+    &#stairsImage {
+      left: -40px;
+      top: 450px;
+
+      @container body (min-width: 1024px) {
+        top: 200px;
+      }
+    }
+
+    &#decagonImage {
+      right: -40px;
+      top: 2850px;
+
+      @container body (min-width: 768px) {
+        top: 1900px;
+      }
+
+      @container body (min-width: 1024px) {
+        right: 0;
+        top: 2000px;
+      }
+    }
+
+    &#exclamationMarkImage {
+      left: -20px;
+      top: 950px;
+
+      @container body (min-width: 1024px) {
+        top: 500px;
+      }
+    }
+
+    &#eyeImage {
+      right: -50px;
+      top: 575px;
+
+      @container body (min-width: 1024px) {
+        top: 650px;
+      }
+    }
+
+    &#squareBubbleImage {
+      left: -40px;
+      top: 2075px;
+
+      @container body (min-width: 1024px) {
+        top: 1550px;
+      }
+    }
+
+    &#secondSquareBubbleImage {
+      right: -50px;
+      top: 850px;
+
+      @container body (min-width: 1024px) {
+        top: 650px;
+      }
+    }
+  }
+}

--- a/styles/sections/_mission.scss
+++ b/styles/sections/_mission.scss
@@ -1,24 +1,6 @@
 @use '../colors';
 
-// TO-DO: ADD IN BACKGROUND IMAGES
-/* #mission {
-  position: relative;
-  height: 100%;
-} */
-
 .mission-header-goals-wrapper {
-  // TO-DO: ADD IN BACKGROUND IMAGES
-  /* &:before {
-    content: ' ';
-    display: block;
-    position: absolute;
-    top: 545px;
-    left: 0;
-    width: 200px;
-    height: 200px;
-    background: url('./assets/stairs-wireframe.svg') no-repeat;
-  } */
-
   h2 {
     margin: 0 0 24px -10px;
 

--- a/styles/sections/_nav.scss
+++ b/styles/sections/_nav.scss
@@ -2,32 +2,37 @@
 
 // Top Navigation Bar
 #top-nav {
-  background: colors.$color-blue;
-  padding: 16px 0;
+  background-color: colors.$color-blue;
   position: sticky;
   top: 0;
   left: 0;
   z-index: 99;
   width: 100%;
-
-  @container body (min-width: 1024px) {
-    padding: 20px 0;
-  }
 }
 
 .container {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  padding: 0 24px;
+  padding: 16px 24px;
+  background: radial-gradient(
+    circle at -100px -110px,
+    colors.$color-teal-50,
+    colors.$color-blue 500px
+  );
 
   @container body (min-width: 1024px) {
-    padding: 0 150px;
+    padding: 20px 150px;
     justify-content: space-between;
+    background: radial-gradient(
+      circle at -100px -200px,
+      colors.$color-teal-50,
+      colors.$color-blue 750px
+    );
   }
 
   @container body (min-width: 1240px) {
-    padding: 0 200px;
+    padding: 20px 200px;
   }
 }
 


### PR DESCRIPTION
- Added background images and gradients to match background Figma designs
- Added gradient to top navigation

How I went about this:
- I ended up hard-coding the images and gradient elements into the code because this allowed me the most control to position them relative to the section they are attached to and to make them work with different screen sizes while also allowing the gradients to flow into other sections. To make this a little more efficient, I created a Sass function to create the background gradient styles.
- With my approach, I ran into a Firefox only bug where the gradient containers had 100% height and were overflowing the body and causing a ton of white space past the footer. I ended up using javascript to make the height of these elements 100% minus their offset from the top so that they would not extend past the body. I'm open to any better fixes for this. :-) 
- The current setup might not be the most flexible if significant changes are made to the html. I had a hard time balancing having flexible styles and also positioning them to stick with the sections they needed to no matter the screen size. I am open to any suggestions for how to make this less hard-coded and more maintainable. :-)